### PR TITLE
Add token-based authentication

### DIFF
--- a/FragCollection.Web/fragcollection-web/src/contexts/AuthContext.tsx
+++ b/FragCollection.Web/fragcollection-web/src/contexts/AuthContext.tsx
@@ -21,9 +21,20 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   useEffect(() => {
     const checkAuth = async () => {
       try {
+        // Check if we have a token in localStorage
+        const token = localStorage.getItem('auth_token');
+        if (!token) {
+          setUser(null);
+          setLoading(false);
+          return;
+        }
+        
+        // If we have a token, validate it by fetching the current user
         const userData = await authApi.getCurrentUser();
         setUser(userData);
       } catch (error) {
+        // On error, clear token and user
+        localStorage.removeItem('auth_token');
         setUser(null);
       } finally {
         setLoading(false);
@@ -65,10 +76,11 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     try {
       setLoading(true);
       await authApi.logout();
-      setUser(null);
     } catch (err: any) {
       setError(err.response?.data?.message || 'Logout failed.');
     } finally {
+      // Always clear user state on logout
+      setUser(null);
       setLoading(false);
     }
   };

--- a/FragCollection/FragCollection.csproj
+++ b/FragCollection/FragCollection.csproj
@@ -9,14 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.4.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FragCollection/JwtHelper.cs
+++ b/FragCollection/JwtHelper.cs
@@ -1,0 +1,36 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using FragCollection.Core.Models;
+
+namespace FragCollection
+{
+    public static class JwtHelper
+    {
+        public static string GenerateJwtToken(User user, string secretKey, int expiryMinutes = 1440)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var key = Encoding.ASCII.GetBytes(secretKey);
+            
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new Claim(ClaimTypes.Name, user.Username),
+                new Claim(ClaimTypes.Email, user.Email)
+            };
+
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(claims),
+                Expires = DateTime.UtcNow.AddMinutes(expiryMinutes),
+                SigningCredentials = new SigningCredentials(
+                    new SymmetricSecurityKey(key), 
+                    SecurityAlgorithms.HmacSha256Signature)
+            };
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            return tokenHandler.WriteToken(token);
+        }
+    }
+}

--- a/FragCollection/appsettings.json
+++ b/FragCollection/appsettings.json
@@ -2,6 +2,9 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=FragCollection;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
+  "JwtSettings": {
+    "Secret": "your_secret_key_here_make_it_at_least_32_characters_long"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
This PR adds token-based authentication to the FragCollection application. 

## Changes:
- Added JWT authentication to the backend
- Modified frontend to store and use authentication tokens
- Updated API client to include token in request headers
- Refactored user authentication logic to support both cookie and token auth
- Added token persistence across page refreshes

This implementation provides a more robust authentication approach for the SPA frontend, preventing session loss when hard refreshing the page.

To test:
1. Login with your credentials
2. Perform a hard refresh (Ctrl+F5)
3. You should still be logged in
4. API requests should now include the token in the Authorization header